### PR TITLE
Updated Google API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-tools-extensions",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1962,6 +1962,55 @@
         }
       }
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.17",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
     "@material-ui/core": {
       "version": "4.9.13",
       "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.9.13.tgz",
@@ -3419,7 +3468,7 @@
     },
     "balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
@@ -3513,7 +3562,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
@@ -4013,8 +4062,8 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "console-browserify": {
@@ -4141,12 +4190,12 @@
       }
     },
     "cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "version": "3.1.5",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "dev": true,
       "requires": {
-        "node-fetch": "2.6.1"
+        "node-fetch": "2.6.7"
       }
     },
     "cross-spawn": {
@@ -4200,9 +4249,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.4",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -5124,6 +5173,15 @@
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
         },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -6008,9 +6066,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.4",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -7769,9 +7827,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "4.1.1",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "mkdirp": {
@@ -9324,18 +9382,18 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.7",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true
     },
     "mixin-deep": {
@@ -9378,9 +9436,9 @@
       }
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.29.4",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "dev": true
     },
     "moo": {
@@ -9403,9 +9461,9 @@
       }
     },
     "nanoid": {
-      "version": "3.1.30",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
+      "version": "3.3.4",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -9457,10 +9515,37 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "version": "2.6.7",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -11838,9 +11923,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "4.1.1",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "strip-ansi": {
@@ -11962,9 +12047,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.4",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -12067,20 +12152,21 @@
       }
     },
     "terser": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
-      "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
+      "version": "5.16.1",
+      "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/terser/-/terser-5.16.1.tgz",
+      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
       "dev": true,
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
         "source-map-support": "~0.5.20"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+        "acorn": {
+          "version": "8.8.1",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/acorn/-/acorn-8.8.1.tgz",
+          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
           "dev": true
         }
       }
@@ -12256,6 +12342,12 @@
           "requires": {
             "minimist": "^1.2.0"
           }
+        },
+        "minimist": {
+          "version": "1.2.7",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/minimist/-/minimist-1.2.7.tgz",
+          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+          "dev": true
         }
       }
     },
@@ -12503,9 +12595,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.4",
+          "resolved": "https://artifactory.devops.ellucian.com/artifactory/api/npm/npmjs/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-tools-extensions",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Productivity Tools extensions",
   "main": "index.js",
   "license": "UNLICENSED",

--- a/src/google/cards/GMailCard.jsx
+++ b/src/google/cards/GMailCard.jsx
@@ -20,7 +20,7 @@ function GmailCard(props) {
     return (
         <ExtensionProvider {...props}>
             <CardProvider {...props}>
-                <AuthProvider>
+                <AuthProvider id="GMail">
                     <MailProvider>
                         <Mail/>
                     </MailProvider>

--- a/src/google/cards/GoogleDriveCard.jsx
+++ b/src/google/cards/GoogleDriveCard.jsx
@@ -20,7 +20,7 @@ function GoogleDriveCard(props) {
     return (
         <ExtensionProvider {...props}>
             <CardProvider {...props}>
-                <AuthProvider>
+                <AuthProvider id="Drive">
                     <DriveProvider>
                         <Drive/>
                     </DriveProvider>

--- a/src/google/context-providers/google-auth-context-provider.js
+++ b/src/google/context-providers/google-auth-context-provider.js
@@ -1,9 +1,7 @@
+/* eslint-disable camelcase */
 // Copyright 2021-2022 Ellucian Company L.P. and its affiliates.
-
 import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-// eslint-disable-next-line camelcase
-import { unstable_batchedUpdates } from 'react-dom';
 
 import { useCache, useCardInfo } from '@ellucian/experience-extension-hooks';
 import { Context } from '../../context-hooks/auth-context-hooks';
@@ -11,84 +9,25 @@ import { Context } from '../../context-hooks/auth-context-hooks';
 import log from 'loglevel';
 const logger = log.getLogger('Google');
 
+let tokenClient;
 const cacheScope = 'google-productivity';
-const lastUserIdCacheKey = 'last-user-id';
+const lastUserIdCacheKey = 'last-user-token';
 const cacheOptions = {
     scope: cacheScope,
     key: lastUserIdCacheKey
 }
 
-function loadGapiScript() {
+function loadScript({ src, identifier }) {
     return new Promise(resolve => {
         const element = document.getElementsByTagName('script')[0];
         const js = document.createElement('script');
-        js.id = 'google-platform';
-        js.src = '//apis.google.com/js/platform.js';
+        js.id = identifier;
+        js.src = src;
         js.async = true;
         js.defer = true;
         element.parentNode.insertBefore(js, element);
         js.onload = () => {
-            resolve(window.gapi);
-        }
-    });
-}
-
-function loadGapi(clientId, setApiState, setLoggedIn, setError, cacheGetItem) {
-    const { gapi } = window;
-    gapi.load('client:auth2', async () => {
-        const discoveryDocs = [
-            'https://www.googleapis.com/discovery/v1/apis/drive/v3/rest',
-            'https://gmail.googleapis.com/$discovery/rest?version=v1'
-        ];
-        const scope = 'https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/gmail.readonly';
-
-        try {
-            await gapi.client.init({
-                clientId: clientId,
-                discoveryDocs,
-                scope
-            });
-
-            const googleAuth = gapi.auth2.getAuthInstance();
-
-            googleAuth.isSignedIn.listen(isSignedIn => {
-                logger.debug('Google isSignedIn changed:', isSignedIn);
-                setLoggedIn(isSignedIn)
-            });
-
-            // Handle the initial sign-in state.
-            const signedIn = googleAuth.isSignedIn.get();
-
-            if (signedIn) {
-                // if user is signed in,
-                // verify that the same user was stored in in cache
-                // if not do a logout
-                const {data: lastUserId} = cacheGetItem(cacheOptions);
-
-                const googleUserId = googleAuth.currentUser.get().getId();
-
-                if (lastUserId !== googleUserId) {
-                    unstable_batchedUpdates(() => {
-                        setLoggedIn(false);
-                        setApiState('do-logout');
-                    });
-                } else {
-                    unstable_batchedUpdates(() => {
-                        setLoggedIn(signedIn);
-                        setApiState('ready');
-                    });
-                }
-            } else {
-                unstable_batchedUpdates(() => {
-                    setLoggedIn(signedIn);
-                    setApiState('ready');
-                });
-            }
-        } catch (error) {
-            if (setError) {
-                setError(error);
-            }
-            logger.error('gapi failed', error);
+            resolve(window[identifier]);
         }
     });
 }
@@ -100,51 +39,143 @@ export function AuthProvider({ children }) {
     const [email, setEmail] = useState();
     const [error, setError] = useState(false);
     const [loggedIn, setLoggedIn] = useState();
-    const [state, setState] = useState('initializing');
 
+    const [state, setState] = useState('initializing');
     const [apiState, setApiState] = useState('init');
 
-    function login(scope) {
-        const { gapi } = window;
-        if (gapi) {
-            const options = {
-                prompt: 'select_account',
-                'ux_mode': 'popup'
-            };
-            if (typeof scope === 'string') {
-                options.scope = scope;
-            }
-            // might be needing to login because of permission issues.
-            // in this case the user is actually logged in
-            // so logout out first so we get notified when they login again.
-            gapi.auth2.getAuthInstance().signOut();
+    function loadGapi(clientId) {
+        const { gapi, google } = window;
+        const { data  = {}} = cacheGetItem(cacheOptions);
 
-            gapi.auth2.getAuthInstance().signIn(options);
+        const discoveryDocs = [
+            'https://www.googleapis.com/discovery/v1/apis/drive/v3/rest',
+            'https://gmail.googleapis.com/$discovery/rest?version=v1'
+        ];
+
+        const scope = 'email https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/gmail.readonly';
+        try {
+            if (gapi && typeof gapi.load === 'function') {
+                gapi.load('client', async () => {
+                    await gapi.client.init({
+                        discoveryDocs
+                    });
+
+                    if (Object.keys(data).length) {
+                        authenticateUser(data.authUser, data.accessToken);
+                    } else {
+                        prepareForLogin();
+                    }
+                });
+
+                tokenClient = google.accounts.oauth2.initTokenClient({
+                    // eslint-disable-next-line camelcase
+                    client_id: clientId,
+                    scope,
+                    callback: (tokenResponse) => {
+                        console.log(tokenResponse);
+                        if (tokenResponse && tokenResponse.access_token) {
+                            authenticateUser(
+                                tokenResponse.authuser,
+                                tokenResponse.access_token,
+                                true
+                            );
+                        }
+                    }
+                });
+            }
+        } catch (error) {
+            setError(error);
+            logger.error('gapi failed', error);
         }
+    }
+
+    function login() {
+        const { gapi } = window;
+        if (gapi.client.getToken() === null) {
+            // Prompt the user to select a Google Account and ask for consent to share their data
+            // when establishing a new session.
+            tokenClient.requestAccessToken({ prompt: 'consent' });
+        } else {
+            // Skip display of account chooser and consent dialog for an existing session.
+            tokenClient.requestAccessToken({ prompt: '' });
+        }
+    }
+
+    function authenticateUser(
+        authUser,
+        accessToken,
+        updateCache = false
+    ) {
+        setEmail(authUser);
+        setLoggedIn(true);
+        setApiState('ready');
+
+        if (updateCache) {
+            cacheStoreItem({
+                ...cacheOptions,
+                data: {
+                    authUser,
+                    accessToken
+                }
+            });
+        } else {
+
+            /**
+             * If updateCache was false, then it probably means page has
+             * been refreshed by user and we need to fetch data
+             * automatically with user token we have.
+             */
+            const { gapi } = window;
+            gapi.client.setToken({
+                access_token: accessToken
+            });
+        }
+    }
+
+    function prepareForLogin() {
+        const { gapi, google } = window;
+        const { data = {} } = cacheGetItem(cacheOptions);
+        if (Object.keys(data).length) {
+            const { accessToken } = data;
+            google.accounts.oauth2.revoke(accessToken);
+            cacheStoreItem({ ...cacheOptions, data: {} });
+        }
+
+        setLoggedIn(false);
+        setEmail('');
+        setApiState('ready');
+        gapi.client.setToken('');
     }
 
     function logout() {
-        const { gapi } = window;
-        if (gapi) {
-            gapi.auth2.getAuthInstance().signOut();
-        }
+        prepareForLogin();
     }
 
     useEffect(() => {
+        const { google, gapi } = window;
         if (apiState === 'init') {
-            const { gapi } = window;
-
-            if (!gapi) {
+            if (!google && !gapi) {
                 ( async() => {
                     setApiState('script-loading');
-                    await loadGapiScript();
+
+                    await Promise.all([
+                        loadScript({
+                            src: '//accounts.google.com/gsi/client',
+                            identifier: 'google'
+                        }),
+                        loadScript({
+                            src: '//apis.google.com/js/api.js',
+                            identifier: 'gapi'
+                        })
+                    ]);
+
                     setApiState('script-loaded');
                 })();
             } else {
                 setApiState('script-loaded');
             }
-        } else if (apiState === 'script-loaded') {
-            loadGapi(googleOAuthClientId, setApiState, setLoggedIn, setError, cacheGetItem);
+        } else if (apiState === 'script-loaded' && gapi) {
+            loadGapi(googleOAuthClientId);
         }
     }, [apiState, setLoggedIn, setError]);
 
@@ -156,19 +187,6 @@ export function AuthProvider({ children }) {
             setApiState('ready');
         }
     }, [apiState]);
-
-    useEffect(() => {
-        if (loggedIn) {
-            const { gapi } = window;
-            const user = gapi.auth2.getAuthInstance().currentUser.get();
-            const email = user.getBasicProfile().getEmail();
-            setEmail(email);
-
-            // store user in cache to detect user changes
-            const googleUserId = gapi.auth2.getAuthInstance().currentUser.get().getId();
-            cacheStoreItem({...cacheOptions, data: googleUserId})
-        }
-    }, [loggedIn]);
 
     const contextValue = useMemo(() => {
         return {

--- a/src/google/context-providers/google-auth-context-provider.js
+++ b/src/google/context-providers/google-auth-context-provider.js
@@ -38,7 +38,7 @@ export function AuthProvider({ children }) {
     const { getItem: cacheGetItem, storeItem: cacheStoreItem } = useCache();
     const { configuration: { googleOAuthClientId } } = useCardInfo();
 
-    const [email, setEmail] = useState();
+    const [user, setUser] = useState({});
     const [error, setError] = useState(false);
     const [loggedIn, setLoggedIn] = useState();
 
@@ -109,7 +109,7 @@ export function AuthProvider({ children }) {
     ) {
         unstable_batchedUpdates(() => {
             setLoggedIn(true);
-            setEmail(authUser);
+            setUser({ authUser });
             setApiState('ready');
 
             if (updateCache) {
@@ -140,7 +140,7 @@ export function AuthProvider({ children }) {
 
         unstable_batchedUpdates(() => {
             setLoggedIn(false);
-            setEmail('');
+            setUser({});
             setApiState('ready');
             gapi.client.setToken('');
         });
@@ -213,7 +213,7 @@ export function AuthProvider({ children }) {
 
     const contextValue = useMemo(() => {
         return {
-            email,
+            user,
             error,
             login,
             logout,
@@ -221,7 +221,7 @@ export function AuthProvider({ children }) {
             setLoggedIn,
             state
         }
-    }, [email, error, loggedIn, login, state]);
+    }, [user, error, loggedIn, login, state]);
 
     useEffect(() => {
         logger.debug('GoogleAuthProvider mounted');

--- a/src/google/context-providers/google-drive-context-provider.js
+++ b/src/google/context-providers/google-drive-context-provider.js
@@ -15,7 +15,7 @@ const logger = log.getLogger('Google');
 const refreshInterval = 60000;
 
 export function DriveProvider({children}) {
-    const { email, loggedIn, setLoggedIn } = useAuth();
+    const { user, loggedIn, setLoggedIn } = useAuth();
 
     const [error, setError] = useState(false);
     const [state, setState] = useState('load');
@@ -113,11 +113,11 @@ export function DriveProvider({children}) {
             error,
             files,
             openDrive: () => {
-                window.open(`https://drive.google.com?authuser=${email}`, '_blank');
+                window.open(`https://drive.google.com?authuser=${user?.authUser}`, '_blank');
             },
             refresh: () => { setState('refresh') }
         }
-    }, [ email, error, files, setState ]);
+    }, [ user, error, files, setState ]);
 
     useEffect(() => {
         logger.debug('GoogleDriveProvider mounted');

--- a/src/google/context-providers/google-mail-context-provider.js
+++ b/src/google/context-providers/google-mail-context-provider.js
@@ -16,7 +16,7 @@ const refreshInterval = 60000;
 
 export function MailProvider({children}) {
     const { locale } = useUserInfo();
-    const { email, loggedIn, setLoggedIn } = useAuth();
+    const { user, loggedIn, setLoggedIn } = useAuth();
 
     const [error, setError] = useState(false);
     const [state, setState] = useState('init');
@@ -32,9 +32,9 @@ export function MailProvider({children}) {
 
     useEffect(() => {
         if (loggedIn && (state === 'load' || state === 'refresh')) {
-            refresh({dateFormater, email, setError, setLoggedIn, setMessages, setState, state, timeFormater });
+            refresh({dateFormater, user, setError, setLoggedIn, setMessages, setState, state, timeFormater });
         }
-    }, [dateFormater, loggedIn, state, timeFormater])
+    }, [dateFormater, user, loggedIn, state, timeFormater])
 
     useEffect(() => {
         let timerId;
@@ -98,7 +98,7 @@ export function MailProvider({children}) {
             error,
             messages,
             openMail: () => {
-                window.open(`https://mail.google.com?authuser=${email}`, '_blank');
+                window.open(`https://mail.google.com?authuser=${user?.authUser}`, '_blank');
             },
             refresh: () => { setState('refresh') },
             state

--- a/src/google/util/events.js
+++ b/src/google/util/events.js
@@ -1,0 +1,14 @@
+function subscribe(eventName, listener) {
+    document.addEventListener(eventName, listener);
+}
+
+function unsubscribe(eventName, listener) {
+    document.removeEventListener(eventName, listener);
+}
+
+function dispatch(eventName, data) {
+    const event = new CustomEvent(eventName, { detail: data });
+    document.dispatchEvent(event);
+}
+
+export { dispatch, subscribe, unsubscribe };

--- a/src/google/util/gmail.js
+++ b/src/google/util/gmail.js
@@ -74,7 +74,7 @@ function isToday(dateToCheck) {
         today.getDate() === dateToCheck.getDate()
 }
 
-export function transformMessages({dateFormater, email, newMessages, timeFormater}) {
+export function transformMessages({dateFormater, user, newMessages, timeFormater}) {
     // transform to what UI needs
     const transformedMessages = newMessages.map( message => {
         const {
@@ -106,7 +106,7 @@ export function transformMessages({dateFormater, email, newMessages, timeFormate
 
         const subject = getValueFromArray(headers, 'Subject', 'No Subject');
 
-        const messageUrl = `https://mail.google.com/mail/?authuser=${email}#all/${id}`;
+        const messageUrl = `https://mail.google.com/mail/?authuser=${user?.authUser}#all/${id}`;
 
         const hasAttachment = parts && parts.some(part => part.filename !== '');
 
@@ -133,12 +133,12 @@ export function transformMessages({dateFormater, email, newMessages, timeFormate
     return transformedMessages;
 }
 
-export async function refresh({dateFormater, email, state, setError, setLoggedIn, setMessages, setState, timeFormater}) {
+export async function refresh({dateFormater, user, state, setError, setLoggedIn, setMessages, setState, timeFormater}) {
     logger.debug(`${state}ing gmail`);
     try {
         const newMessages = await getMessagesFromThreads();
 
-        const transformedMessages = transformMessages({dateFormater, email, newMessages, timeFormater});
+        const transformedMessages = transformMessages({dateFormater, user, newMessages, timeFormater});
 
         logger.debug('Gmail messages: ', transformedMessages);
 

--- a/src/google/util/google-scripts.js
+++ b/src/google/util/google-scripts.js
@@ -1,0 +1,137 @@
+import { dispatch } from './events';
+import log from 'loglevel';
+const logger = log.getLogger('Google');
+
+function loadScript({ src, identifier }) {
+    logger.debug(`google-scripts loadScript for ${src} : ${identifier}`);
+    return new Promise(resolve => {
+        const element = document.getElementsByTagName('script')[0];
+        const js = document.createElement('script');
+        js.id = identifier;
+        js.src = src;
+        js.async = true;
+        js.defer = true;
+        element.parentNode.insertBefore(js, element);
+        js.onload = () => {
+            resolve(window[identifier]);
+        }
+    });
+}
+
+// initializes GAPI. Needed context is stored globally in window.
+async function loadGoogleScripts({ providerId }) {
+    const { gapi, google } = window;
+
+    if (!gapi && !google) {
+        logger.debug(`google-scripts ${providerId} loading scripts`);
+        await Promise.all([
+            loadScript({
+                src: '//accounts.google.com/gsi/client',
+                identifier: 'google-script'
+            }),
+            loadScript({
+                src: '//apis.google.com/js/api.js',
+                identifier: 'gapi-script'
+            })
+        ]);
+
+        logger.debug(`google-scripts ${providerId} loaded scripts`);
+    }
+}
+
+// initializes GAPI. Needed context is stored globally in window.
+function initGapi({ providerId }){
+    const { gapi } = window;
+
+    if ( gapi && typeof gapi.load === 'function') {
+        logger.debug(`google-scripts ${providerId} initializing gapi`);
+            const discoveryDocs = [
+                'https://www.googleapis.com/discovery/v1/apis/drive/v3/rest',
+                'https://gmail.googleapis.com/$discovery/rest?version=v1'
+            ];
+
+            return new Promise(resolve => {
+                gapi.load('client', async () => {
+                    await gapi.client.init({
+                        discoveryDocs
+                    });
+                    resolve();
+                })
+
+            });
+    } else {
+        logger.debug(`google-scripts ${providerId} initGapi gapi not ready`);
+        return Promise.reject(new Error('initGapi failed'));
+    }
+}
+
+// initialize the auth2 token client. Needed context is stored globally in window.
+const googleScope = 'email https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/gmail.readonly';
+function initAuth2TokenClient({ clientId, providerId }){
+    const { google, googleScriptContext: { tokenClient } = {} } = window;
+
+    if ( google && !tokenClient ) {
+        logger.debug(`google-scripts ${providerId} initializaing TokenClient`);
+        const newTokenClient = google.accounts.oauth2.initTokenClient({
+            'client_id': clientId,
+            scope: googleScope,
+            callback: (tokenResponse) => {
+                logger.debug(`google-scripts ${providerId} token callback: ${JSON.stringify(tokenResponse)}`);
+                if (tokenResponse && tokenResponse.access_token) {
+                    dispatch('google-event', {
+                        reason: 'user-authenticated',
+                        authUser: tokenResponse.authuser,
+                        accessToken: tokenResponse.access_token
+                    });
+                }
+            }
+        });
+
+        window.googleScriptContext.tokenClient = newTokenClient;
+    }
+}
+
+async function doInitialize(options) {
+    try {
+        await loadGoogleScripts(options);
+        await initGapi(options);
+        initAuth2TokenClient(options);
+
+        window.googleScriptContext.state = 'ready';
+        logger.debug(`google-scripts ${options.providerId} doInitialize done: 'ready'`);
+
+        dispatch('google-event', {
+            reason: 'ready'
+        })
+    } catch (error) {
+        dispatch('google-event', {
+            reason: 'error'
+        })
+    }
+}
+
+export function initialize(options) {
+    const { googleScriptContext = {} } = window;
+    window.googleScriptContext = googleScriptContext;
+    const { state = 'init' } = googleScriptContext;
+
+    if (state === 'init') {
+        logger.debug(`google-scripts ${options.providerId} first to initialize`);
+        googleScriptContext.state = 'initializing';
+        doInitialize(options);
+
+        return 'initializing';
+    } else if (state === 'ready') {
+        logger.debug(`google-scripts ${options.providerId} ready`);
+        return 'ready';
+    }
+
+    logger.debug(`google-scripts ${options.providerId} already initializing`);
+    return 'initializing';
+}
+
+export function getTokenClient(){
+    const { googleScriptContext: { tokenClient } = {} } = window;
+
+    return tokenClient;
+}

--- a/src/google/util/google-scripts.js
+++ b/src/google/util/google-scripts.js
@@ -72,6 +72,7 @@ function initAuth2TokenClient({ clientId, providerId }){
 
     if ( google && !tokenClient ) {
         logger.debug(`google-scripts ${providerId} initializaing TokenClient`);
+        const now = new Date();
         const newTokenClient = google.accounts.oauth2.initTokenClient({
             'client_id': clientId,
             scope: googleScope,
@@ -81,7 +82,8 @@ function initAuth2TokenClient({ clientId, providerId }){
                     dispatch('google-event', {
                         reason: 'user-authenticated',
                         authUser: tokenResponse.authuser,
-                        accessToken: tokenResponse.access_token
+                        accessToken: tokenResponse.access_token,
+                        expiresIn: now.setSeconds(now.getSeconds() + tokenResponse.expires_in)
                     });
                 }
             }

--- a/src/i18n/fr-CA.json
+++ b/src/i18n/fr-CA.json
@@ -2,7 +2,7 @@
   "messages": {
     "error.contentNotAvailable": "Contenu non disponible",
     "error.contactYourAdministrator": "Contactez votre administrateur",
-    "drive.modified": "Modifié par: {name}"
+    "drive.modified": "Modifié par: {name}",
     "drive.modifiedBy": "Modifié le {date} par {name}",
     "google.permissionsRequested": "Permissions demandées",
     "google.noFilesTitle": "Aucun fichier dans Google Drive",


### PR DESCRIPTION
I've removed the google `apis.google.com/js/platform.js` and have added the new `accounts.google.com/gsi/client` js file.

Google has segregated the authentication and authorisation process separately and our new `GSI` client handles only the authentication process. For authorisation, we need to load the `//apis.google.com/js/api.js` so that we'll have the instance of `gapi.client.drive` and `gapi.client.gmail` respectively upon authentication.

Also, we no longer receive the email on the successful authentication, instead we simply receive the `access_token` for accessing drive and gmail along with the `authuser` ie, if we have 2 gmail accounts currently logged in our browser, say A and B, then account A will be authuser `0` and account B will be authuser `1`. With the help of authuser we can handle the events to open the file or email when clicked for that particular user by swapping the our existing implementation of `email` with `authuser`.

Functionalities added

- Since google.isSignedIn event is removed, I've created a custom event for handling user authentication during sign in/sign out to reflect on both the cards.
- Swapped the `email` state from `google-auth-context-provider.js` with `user` object. I have used object so that in future if we need couple of more user params, we can simply update the object and it'll be available across the system.

